### PR TITLE
Feature/remove libpcap dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROGNAME=nfq2pcap
 CC=gcc
 CFLAGS=-Wall -O2 -g
-OBJS=nfq2pcap.c
+OBJS=nfq2pcap.c pcap-writer.c
 LIBS=-lc -lpcap -lnetfilter_queue
 
 .c.o:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PROGNAME=nfq2pcap
 CC=gcc
 CFLAGS=-Wall -O2 -g
 OBJS=nfq2pcap.c pcap-writer.c
-LIBS=-lc -lpcap -lnetfilter_queue
+LIBS=-lc -lnetfilter_queue
 
 .c.o:
 	$(CC) -c $< -o $@ $(CFLAGS)

--- a/nfq2pcap.h
+++ b/nfq2pcap.h
@@ -18,6 +18,8 @@
 
 #define DEFAULT_VERDICT     NF_ACCEPT
 
+#define DEFAULT_DLT_RAWIPV4 DLT_IPV4
+
 // Helper macro to display error messages in bold red text
 #define error_msg(fmt, args...) \
     fprintf(stderr, "\033[1;31m"); \
@@ -31,6 +33,7 @@ typedef struct _callback_args {
     uint32_t        queue_num;
     uint32_t        target_queue;   // Only relevant if verdict == NF_QUEUE
     char *          output_filename;
+    uint32_t        dlt;            // Here so we can send to parse_args()
 } callback_args;
 
 static inline char *verdict_to_str(uint32_t verdict)

--- a/nfq2pcap.h
+++ b/nfq2pcap.h
@@ -3,8 +3,8 @@
 
 #include <stdint.h>
 #include <linux/netfilter.h>  // For NF_ACCEPT
-#include <pcap/pcap.h>
 
+#include "pcap-writer.h"
 
 #define DEFAULT_OUT_FILENAME "output.pcap"
 
@@ -13,6 +13,8 @@
 #define DEFAULT_TARGET_ID   1
 
 #define PACKET_BUFF_MAX 65535
+
+#define DEFAULT_SNAPLEN 65535
 
 #define DEFAULT_VERDICT     NF_ACCEPT
 
@@ -24,7 +26,7 @@
 
 // Arguments passed into the callback as user-supplied args
 typedef struct _callback_args {
-    pcap_dumper_t   *dumper;
+    PcapWriter      *writer;
     uint32_t        verdict;
     uint32_t        queue_num;
     uint32_t        target_queue;   // Only relevant if verdict == NF_QUEUE

--- a/pcap-writer.c
+++ b/pcap-writer.c
@@ -129,7 +129,8 @@ static int pcap_writer_write_header(PcapWriter *writer)
 // Return's boolean indicating success or failure
 uint32_t pcap_writer_write_packet(PcapWriter *writer,
                                   unsigned char *packet_data,
-                                  uint32_t data_len, uint32_t real_len)
+                                  uint32_t ll_header_len, uint32_t data_len,
+                                  uint32_t real_len)
 {
     if (writer == NULL || packet_data == NULL) { return false; }
     if (writer->file == NULL) { return false; }
@@ -149,20 +150,15 @@ uint32_t pcap_writer_write_packet(PcapWriter *writer,
     packet_header->included_len = data_len;
     packet_header->real_len = real_len;
 
-    printf("PH->included_len:        %d\n", packet_header->included_len);
-    printf("PH->real_len:            %d\n", packet_header->real_len);
-
     // Write the pcap packet header
     int bytes_written = fwrite(packet_header,
                                1, sizeof(PcapPacketHeader),
                                writer->file);
-    printf("Wrote %d of %d bytes for packet header\n", bytes_written, sizeof(PcapPacketHeader));
 
     // Write packet-data, including Link-layer header
     bytes_written = fwrite(packet_data,
                            1, data_len,
                            writer->file);
-    printf("Wrote %d of %d bytes for packet data\n", bytes_written, data_len);
 
     fflush(writer->file);
     writer->bytes_written += sizeof(PcapPacketHeader);

--- a/pcap-writer.c
+++ b/pcap-writer.c
@@ -131,8 +131,8 @@ uint32_t pcap_writer_write_packet(PcapWriter *writer,
                                   unsigned char *packet_data,
                                   uint32_t data_len, uint32_t real_len)
 {
-    if (writer == NULL || packet_data == NULL) { return -1; }
-    if (writer->file == NULL) { return -1; }
+    if (writer == NULL || packet_data == NULL) { return false; }
+    if (writer->file == NULL) { return false; }
 
     // Make sure header has been written
     if (writer->header_written == false) {

--- a/pcap-writer.c
+++ b/pcap-writer.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <stdbool.h>
 
 #include "pcap-writer.h"
@@ -57,7 +58,7 @@ PcapWriter *pcap_writer_new(char *filename,
     // Duplicate file name string
     new_writer->filename = strdup(filename);
     if (new_writer->filename == NULL) {
-        free(file_header)
+        free(file_header);
         free(new_writer);
         return NULL;
     }
@@ -68,7 +69,7 @@ PcapWriter *pcap_writer_new(char *filename,
     new_writer->header_written = false;
 
     // Open the output file
-    FILE *out_file = NULL
+    FILE *out_file = NULL;
     out_file = fopen(filename, "wb");
     if (out_file == NULL) {
         pcap_file_header_free(file_header);

--- a/pcap-writer.c
+++ b/pcap-writer.c
@@ -1,0 +1,103 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include "pcap-writer.h"
+
+static PcapFileHeader *pcap_file_header_new(uint32_t snaplen,
+                                            uint32_t dll_type)
+{
+    PcapFileHeader *file_header = NULL;
+
+    file_header = (PcapFileHeader *)calloc(1, sizeof(PcapFileHeader));
+    if (file_header == NULL) {
+        return NULL;
+    }
+
+    // Setup values
+    file_header->magic_number = PCAP_MAGIC_NUMBER;
+    file_header->version_major = PCAP_MAJOR_VERSION;
+    file_header->version_minor = PCAP_MINOR_VERSION;
+    file_header->this_timezone = 0;
+    file_header->sigfigs = 0;
+    file_header->snaplen = snaplen;
+    file_header->network = dll_type;
+
+    return file_header;
+}
+
+static void pcap_file_header_free(PcapFileHeader *file_header)
+{
+    if (file_header == NULL) { return; }
+    free(file_header);
+}
+
+// Dynamically allocates memory for data structures,
+// creates and opens the output file
+// Returns NULL on failure, check errno
+PcapWriter *pcap_writer_new(char *filename,
+                            uint32_t snaplen,
+                            uint32_t dll_type)
+{
+    PcapWriter *new_writer = NULL;
+
+    new_writer = (PcapWriter *)calloc(1, sizeof(PcapWriter));
+    if (new_writer == NULL) {
+        return NULL;
+    }
+
+    // Create file header structure
+    PcapFileHeader *file_header = pcap_file_header_new(snaplen, dll_type);
+    if (file_header == NULL) {
+        free(new_writer);
+        return NULL;
+    }
+    new_writer->file_header = file_header;
+
+    // Duplicate file name string
+    new_writer->filename = strdup(filename);
+    if (new_writer->filename == NULL) {
+        free(file_header)
+        free(new_writer);
+        return NULL;
+    }
+
+    // zero integers
+    new_writer->bytes_written = 0;
+    new_writer->packets_written = 0;
+    new_writer->header_written = false;
+
+    // Open the output file
+    FILE *out_file = NULL
+    out_file = fopen(filename, "wb");
+    if (out_file == NULL) {
+        pcap_file_header_free(file_header);
+        free(new_writer->filename);
+        free(new_writer);
+        return NULL;
+    }
+
+    // We made it!
+    return new_writer;
+}
+
+void pcap_writer_close(PcapWriter *writer) {
+    if (writer == NULL || writer->file == NULL) { return; }
+    fclose(writer->file);
+    writer->file = NULL;
+}
+
+void pcap_writer_free(PcapWriter *writer)
+{
+    if (writer == NULL) { return; }
+    if (writer->file_header != NULL) {
+        pcap_file_header_free(writer->file_header);
+    }
+    if (writer->filename != NULL) {
+        free(writer->filename);
+    }
+
+    //  Close the underlying file, in case it hasn't been done already
+    if (writer->file != NULL) { pcap_writer_close(writer); }
+    free(writer);
+}

--- a/pcap-writer.c
+++ b/pcap-writer.c
@@ -82,7 +82,35 @@ PcapWriter *pcap_writer_new(char *filename,
     return new_writer;
 }
 
-void pcap_writer_close(PcapWriter *writer) {
+static int pcap_writer_write_header(PcapWriter *writer)
+{
+    if (writer == NULL || writer->file == NULL) { return; }
+    if (writer->header_written == true) { return; }
+
+    size_t written_bytes = 0;
+
+    written_bytes = fwrite(writer->file_header, 1, sizeof(PcapFileHeader),
+                           writer->file);
+
+    if (written_bytes < sizeof(PcapFileHeader)) {
+        return false;
+    }
+
+    writer->header_written = true;
+    fflush(writer->file);
+    writer->bytes_written += written_bytes;
+
+    return true;
+}
+
+uint32_t pcap_writer_write_packet(PcapWriter *writer, char *packet_data,
+                                  uint32_t data_len, uint32_t real_len)
+{
+
+}
+
+void pcap_writer_close(PcapWriter *writer)
+{
     if (writer == NULL || writer->file == NULL) { return; }
     fclose(writer->file);
     writer->file = NULL;
@@ -102,3 +130,4 @@ void pcap_writer_free(PcapWriter *writer)
     if (writer->file != NULL) { pcap_writer_close(writer); }
     free(writer);
 }
+

--- a/pcap-writer.h
+++ b/pcap-writer.h
@@ -5,7 +5,7 @@
 #define __PCAP_WRITER_H__
 
 #include <stdio.h>
-#include <stdint.n>
+#include <stdint.h>
 
 const uint32_t PCAP_MAGIC_NUMBER = 0xa1b2c3d4;
 

--- a/pcap-writer.h
+++ b/pcap-writer.h
@@ -7,11 +7,13 @@
 #include <stdio.h>
 #include <stdint.h>
 
-const uint32_t PCAP_MAGIC_NUMBER = 0xa1b2c3d4;
+#define PCAP_MAGIC_NUMBER  0xa1b2c3d4
 
 // PCAP file version numbers, current as of March 2020
-const uint16_t PCAP_MAJOR_VERSION = 2;
-const uint16_t PCAP_MINOR_VERSION = 4;
+// const uint16_t PCAP_MAJOR_VERSION = 2;
+// const uint16_t PCAP_MINOR_VERSION = 4;
+#define PCAP_MAJOR_VERSION  2
+#define PCAP_MINOR_VERSION  4
 
 typedef struct _pcap_file_header {
     uint32_t    magic_number;
@@ -47,6 +49,27 @@ PcapWriter *pcap_writer_new(char *filename,
                             uint32_t dll_type);
 void pcap_writer_free(PcapWriter *writer);
 void pcap_writer_close(PcapWriter *writer);
+uint32_t pcap_writer_write_packet(PcapWriter *writer,
+                                  unsigned char *packet_data,
+                                  uint32_t data_len, uint32_t real_len);
 PcapPacketHeader *pcap_writer_packet_header_new();
 void pcap_writer_packet_header_free(PcapPacketHeader *header);
+
+// Data Link Type (DLT_) definitions.
+// Obtained from information at: http://www.tcpdump.org/linktypes.html
+// (Mar 2020).
+// Only a select few have been included here
+#define     DLT_NULL                0
+#define     DLT_EN10MB              1
+#define     DLT_AX25                3
+#define     DLT_IEEE802             6
+#define     DLT_ARCNET              7
+#define     DLT_SLIP                8
+#define     DLT_PPP                 9
+#define     DLT_FDDI                10
+#define     DLT_PPP_SERIAL          50
+
+#define     DLT_IPV4                228     // Packet begins with raw IPV4
+#define     DLT_IPV6                229     // Packet begins with raw IPV6
+
 #endif  /* End __PCAP_WRITER_H__ */

--- a/pcap-writer.h
+++ b/pcap-writer.h
@@ -47,4 +47,6 @@ PcapWriter *pcap_writer_new(char *filename,
                             uint32_t dll_type);
 void pcap_writer_free(PcapWriter *writer);
 void pcap_writer_close(PcapWriter *writer);
+PcapPacketHeader *pcap_writer_packet_header_new();
+void pcap_writer_packet_header_free(PcapPacketHeader *header);
 #endif  /* End __PCAP_WRITER_H__ */

--- a/pcap-writer.h
+++ b/pcap-writer.h
@@ -1,0 +1,50 @@
+// Pcap file format information obtained from (March 2020):
+// https://wiki.wireshark.org/Development/LibpcapFileFormat
+
+#ifndef __PCAP_WRITER_H__
+#define __PCAP_WRITER_H__
+
+#include <stdio.h>
+#include <stdint.n>
+
+const uint32_t PCAP_MAGIC_NUMBER = 0xa1b2c3d4;
+
+// PCAP file version numbers, current as of March 2020
+const uint16_t PCAP_MAJOR_VERSION = 2;
+const uint16_t PCAP_MINOR_VERSION = 4;
+
+typedef struct _pcap_file_header {
+    uint32_t    magic_number;
+    uint16_t    version_major;
+    uint16_t    version_minor;
+    int32_t     this_timezone;      // GMT-to-local correction, in seconds
+    uint32_t    sigfigs;        // Accuracy of timestamps, usually set to 0
+    uint32_t    snaplen;        // Max length of captured packets, in bytes
+    uint32_t    network;        // Data Link Type
+} PcapFileHeader;
+
+typedef struct _pcap_packet_header {
+    uint32_t    ts_sec;         // Timestamp seconds
+    uint32_t    ts_usec;        // Timestamp microseconds
+    uint32_t    included_len;   // Included number of bytes for packet
+    uint32_t    real_len;       // Actual length of packet
+} PcapPacketHeader;
+
+typedef struct _pcap_writer {
+    FILE *      file;
+    uint64_t    bytes_written;
+    uint64_t    packets_written;
+    uint8_t     header_written;
+    char *      filename;
+    PcapFileHeader *file_header;
+} PcapWriter;
+
+// 
+// Function prototypes.
+// 
+PcapWriter *pcap_writer_new(char *filename,
+                            uint32_t snaplen,
+                            uint32_t dll_type);
+void pcap_writer_free(PcapWriter *writer);
+void pcap_writer_close(PcapWriter *writer);
+#endif  /* End __PCAP_WRITER_H__ */

--- a/pcap-writer.h
+++ b/pcap-writer.h
@@ -51,7 +51,9 @@ void pcap_writer_free(PcapWriter *writer);
 void pcap_writer_close(PcapWriter *writer);
 uint32_t pcap_writer_write_packet(PcapWriter *writer,
                                   unsigned char *packet_data,
-                                  uint32_t data_len, uint32_t real_len);
+                                  uint32_t ll_header_len,
+                                  uint32_t data_len,
+                                  uint32_t real_len);
 PcapPacketHeader *pcap_writer_packet_header_new();
 void pcap_writer_packet_header_free(PcapPacketHeader *header);
 


### PR DESCRIPTION
Implement own PCAP-writing code.

Drop use of DLT_NULL due to issues getting the link headers to behave, seemingly missing packets??